### PR TITLE
feat: add granular theme for different card modal elements

### DIFF
--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -30,19 +30,37 @@ interface BaseThemeOptions {
   colors: Partial<ThemeColorVariants>
 }
 
+export interface CardModalTheme {
+  card: Partial<CSSStyleDeclaration>
+  header: Partial<CSSStyleDeclaration>
+  body: Partial<CSSStyleDeclaration>
+  button: Partial<CSSStyleDeclaration>
+}
+
+export type CardModalVariant =
+  | 'base'
+  | 'checkoutForm'
+  | 'selectFreePlanConfirmation'
+  | 'cancelConfirmation'
+  | 'switchPlanConfirmation'
+  | 'customConfirm'
+  | 'renewConfirmation'
+  | 'paymentConfirmation'
+
+export type CardModalVariants = {
+  [key in CardModalVariant]: Partial<CardModalTheme>
+}
+
 export interface IPublicThemeFull {
   base: Partial<BaseThemeOptions>
   card: Partial<CSSStyleDeclaration>
   button: Partial<ThemeButtonVariants>
   planPrice: Partial<CSSStyleDeclaration>
   planBillingPeriod: Partial<CSSStyleDeclaration>
-  cardModal: Partial<CSSStyleDeclaration>
-  cardModalHeader: Partial<CSSStyleDeclaration>
-  cardModalBody: Partial<CSSStyleDeclaration>
-  cardModalButton: Partial<CSSStyleDeclaration>
+  cardModal: Partial<CardModalVariants>
 }
-export type IPublicTheme = Partial<IPublicThemeFull>
 
+export type IPublicTheme = Partial<IPublicThemeFull>
 export interface IFrameOptions {
   url: string | URL
   theme?: IPublicTheme

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -30,11 +30,10 @@ interface BaseThemeOptions {
   colors: Partial<ThemeColorVariants>
 }
 
-export interface CardModalTheme {
-  card: Partial<CSSStyleDeclaration>
-  header: Partial<CSSStyleDeclaration>
-  body: Partial<CSSStyleDeclaration>
-  button: Partial<CSSStyleDeclaration>
+export type CardElement = 'card' | 'header' | 'body' | 'button'
+
+export type CardModalTheme = {
+  [key in CardElement]: Partial<CSSStyleDeclaration>
 }
 
 export type CardModalVariant =
@@ -43,7 +42,7 @@ export type CardModalVariant =
   | 'selectFreePlanConfirmation'
   | 'cancelConfirmation'
   | 'switchPlanConfirmation'
-  | 'customConfirm'
+  | 'customPlanConfirmation'
   | 'renewConfirmation'
   | 'paymentConfirmation'
 


### PR DESCRIPTION
supports e.g.:

```
const theme = {
  cardModal: {
    base: {
      header: // css applied to all card modal headers
    },
    checkoutForm: {
      header: // css applied to only checkout form's header
    }
  }
}
```